### PR TITLE
Mute and Deafen Multi-Action Support

### DIFF
--- a/Sources/MyStreamDeckPlugin.cpp
+++ b/Sources/MyStreamDeckPlugin.cpp
@@ -24,6 +24,8 @@ LICENSE file.
 
 namespace {
 const auto MUTE_ACTION_ID = "com.fredemmott.discord.mute";
+const auto MUTE_ACTION_ON_ID = "com.fredemmott.discord.muteon";
+const auto MUTE_ACTION_OFF_ID = "com.fredemmott.discord.muteoff";
 const auto DEAFEN_ACTION_ID = "com.fredemmott.discord.deafen";
 
 const auto RECONNECT_PI_ACTION_ID = "com.fredemmott.discord.rpc.reconnect";
@@ -86,6 +88,14 @@ void MyStreamDeckPlugin::KeyUpForAction(
   const auto oldState = EPLJSONUtils::GetIntByName(inPayload, "state");
   if (inAction == MUTE_ACTION_ID) {
     mClient->setIsMuted(oldState == 0);
+    return;
+  }
+  if (inAction == MUTE_ACTION_ON_ID) {
+    mClient->setIsMuted(1);
+    return;
+  }
+  if (inAction == MUTE_ACTION_OFF_ID) {
+    mClient->setIsMuted(0);
     return;
   }
   if (inAction == DEAFEN_ACTION_ID) {

--- a/Sources/MyStreamDeckPlugin.cpp
+++ b/Sources/MyStreamDeckPlugin.cpp
@@ -27,6 +27,8 @@ const auto MUTE_ACTION_ID = "com.fredemmott.discord.mute";
 const auto MUTE_ACTION_ON_ID = "com.fredemmott.discord.muteon";
 const auto MUTE_ACTION_OFF_ID = "com.fredemmott.discord.muteoff";
 const auto DEAFEN_ACTION_ID = "com.fredemmott.discord.deafen";
+const auto DEAFEN_ACTION_ON_ID = "com.fredemmott.discord.deafenon";
+const auto DEAFEN_ACTION_OFF_ID = "com.fredemmott.discord.deafenoff";
 
 const auto RECONNECT_PI_ACTION_ID = "com.fredemmott.discord.rpc.reconnect";
 const auto REAUTHENTICATE_PI_ACTION_ID
@@ -100,6 +102,14 @@ void MyStreamDeckPlugin::KeyUpForAction(
   }
   if (inAction == DEAFEN_ACTION_ID) {
     mClient->setIsDeafened(oldState == 0);
+    return;
+  }
+  if (inAction == DEAFEN_ACTION_ON_ID) {
+    mClient->setIsDeafened(1);
+    return;
+  }
+  if (inAction == DEAFEN_ACTION_OFF_ID) {
+    mClient->setIsDeafened(0);
     return;
   }
 }

--- a/sdPlugin/manifest.json.cmake
+++ b/sdPlugin/manifest.json.cmake
@@ -15,6 +15,30 @@
       "Tooltip": "Toggle Self-Mute in Discord",
       "UUID": "com.fredemmott.discord.mute"
     },
+    {
+      "Icon": "discord-mic-off",
+      "States": [
+        {
+          "Image": "discord-mic-off"
+        }
+      ],
+      "SupportedInMultiActions": true,
+      "Name": "Discord Mute On",
+      "Tooltip": "Set Self-Mute in Discord to On",
+      "UUID": "com.fredemmott.discord.muteon"
+    },
+    {
+      "Icon": "discord-mic-on",
+      "States": [
+        {
+          "Image": "discord-mic-on"
+        }
+      ],
+      "SupportedInMultiActions": true,
+      "Name": "Discord Mute Off",
+      "Tooltip": "Set Self-Mute in Discord to Off",
+      "UUID": "com.fredemmott.discord.muteoff"
+    },
 	{
       "Icon": "discord-deafen-off", 
       "States": [

--- a/sdPlugin/manifest.json.cmake
+++ b/sdPlugin/manifest.json.cmake
@@ -53,6 +53,30 @@
 	    "Name": "Toggle Discord Deafen",
       "Tooltip": "Toggle Self-Mute in Deafen",
       "UUID": "com.fredemmott.discord.deafen"
+    },
+    {
+      "Icon": "discord-deafen-on", 
+      "States": [
+        {
+          "Image": "discord-deafen-on"
+        }
+      ],
+      "SupportedInMultiActions": true,
+      "Name": "Set Discord Deafen On",
+      "Tooltip": "Set Self-Mute in Deafen to On",
+      "UUID": "com.fredemmott.discord.deafenon"
+    },
+    {
+      "Icon": "discord-deafen-off", 
+      "States": [
+        {
+          "Image": "discord-deafen-off"
+        }
+      ],
+      "SupportedInMultiActions": true,
+      "Name": "Set Discord Deafen Off",
+      "Tooltip": "Set Self-Mute in Deafen Off",
+      "UUID": "com.fredemmott.discord.deafenoff"
     }
   ], 
   "Author": "Fred Emmott", 


### PR DESCRIPTION
I tried to get the set mute/deafen on and off working with as little changes as possible. A better way to do this would be to add a value option in the property inspector HTML to change between mute and unmute. That would use fewer actions but be more complex to implement because each action instance would need to store a different value. Tested on Windows 10 and works very well.